### PR TITLE
Add windows support

### DIFF
--- a/csfml.nim
+++ b/csfml.nim
@@ -5,6 +5,11 @@ when defined(linux):
     LibG = "libcsfml-graphics.so.2.(1|0)"
     LibS = "libcsfml-system.so.2.(1|0)"
     LibW = "libcsfml-window.so.2.(1|0)"
+elif defined(windows):
+  const
+    LibG = "csfml-graphics-(2.|2.1.)dll"
+    LibS = "csfml-system-(2.|2.1.)dll"
+    LibW = "csfml-window-(2.|2.1.)dll"
 else:
   {.error: "Platform unsupported".}
 {.deadCodeElim: on.}
@@ -155,10 +160,10 @@ type
     KeyCount              #/< Keep last -- the total number of keyboard keys
 when defined(linux): #or defined(bsd) ??
   type TWindowHandle* = clong
+elif defined(windows):
+  type TWindowHandle* = pointer    ##HWND__ ? windows is crazy. ##struct HWND__; typedef struct HWND__* sfWindowHandle;
 #elif defined(mac):
 #  type TWindowHandle* = pointer ##typedef void* sfWindowHandle; <- whatever the hell that is
-#elif defined(windows):
-#  type TWindowHandle* = HWND__ ? windows is crazy. ##struct HWND__; typedef struct HWND__* sfWindowHandle;
 const
   sfNone*         = 0
   sfTitlebar*     = 1 shl 0

--- a/csfml_audio.nim
+++ b/csfml_audio.nim
@@ -1,7 +1,13 @@
 import
   csfml
-const
-  Lib = "libcsfml-audio.so.2.(1|0)"
+when defined(linux):
+  const
+    Lib = "libcsfml-audio.so.2.(1|0)"
+elif defined(windows):
+  const
+    Lib = "csfml-audio-(2.|2.1.)dll"
+else:
+  {.error: "Platform unsupported".}
 {.deadCodeElim: on.}
 type
   PMusic* = ptr TMusic


### PR DESCRIPTION
Hi,

This change works for me to get it working on windows using the dll's from here: http://www.sfml-dev.org/download/csfml/

I don't know what " ##HWND__ ? windows is crazy. ##struct HWND__; typedef struct HWND__\* sfWindowHandle;" is all about, but pointer seems to work for me....

Cheers, Rien
