### PR TITLE
Minor fixes and case sensitivity

### DIFF
--- a/csfml.nim
+++ b/csfml.nim
@@ -15,7 +15,6 @@ else:
 {.deadCodeElim: on.}
 {.pragma: pf, pure, final.}
 type
-  microseconds* = int64
   PClock* = ptr TClock
   TClock* {.pf.} = object
   TTime* {.pf.} = object
@@ -1178,12 +1177,12 @@ proc Microseconds*(us: int64): TTime #{.  cdecl, importc: "sfMicroseconds", dynl
 
 {.pop.}
 
-proc `-`*(a, b: csfml.TTime): csfml.TTime {.inline.} = TTime(microseconds: (a.asMicroseconds - b.asMicroseconds))
+proc `-`*(a, b: csfml.TTime): csfml.TTime {.inline.} = Microseconds(a.asMicroseconds - b.asMicroseconds)
 proc `-=`*(a: var csfml.TTime; b: csfml.TTime) {.inline.} = a = a - b
-proc `+`*(a, b: csfml.TTime): csfml.TTime {.inline.} = TTime(microseconds: (a.asMicroseconds + b.asMicroseconds))
+proc `+`*(a, b: csfml.TTime): csfml.TTime {.inline.} = Microseconds(a.asMicroseconds + b.asMicroseconds)
 proc `+=`*(a: var csfml.TTime; b: csfml.TTime) {.inline.} = a = a + b
 proc `<`*(a, b: csfml.TTime): bool {.inline.} = a.asMicroseconds < b.asMicroseconds
-let ZeroTime* = microseconds(0)
+let ZeroTime* = Microseconds(0)
 
 
 proc newContextSettings*(depthBits: cint = 0,

--- a/csfml.nim
+++ b/csfml.nim
@@ -1372,4 +1372,4 @@ proc setMousePosition*(window: PWindow; pos: TVector2i) {.inline.} =
 {.pop.}
 {.pop.}
 
-proc newClock*(): PClock {.inline.} = Clock_Create()
+proc newClock*(): PClock {.inline.} = Clock_create()

--- a/csfml.nim
+++ b/csfml.nim
@@ -15,6 +15,7 @@ else:
 {.deadCodeElim: on.}
 {.pragma: pf, pure, final.}
 type
+  microseconds* = int64
   PClock* = ptr TClock
   TClock* {.pf.} = object
   TTime* {.pf.} = object
@@ -220,10 +221,10 @@ type
   TTransform* {.pf.} = object
     matrix*: array[0..8, cfloat]
   TColor* {.pf.} = object 
-    r*: Uint8
-    g*: Uint8
-    b*: Uint8
-    a*: Uint8
+    r*: uint8
+    g*: uint8
+    b*: uint8
+    a*: uint8
   PFloatRect* = ptr TFloatRect
   TFloatRect*{.pf.} = object 
     left*: cfloat
@@ -418,7 +419,7 @@ proc setMousePosition*(pos: TVector2i, window: PRenderWindow) {.
 {.pop.}
 
 #Construct a new render texture
-proc newRenderTexture*(width, height: cint; depthBuffer: Bool): PRenderTexture {.
+proc newRenderTexture*(width, height: cint; depthBuffer: bool): PRenderTexture {.
   cdecl, importc: "sfRenderTexture_create", dynlib: LibG.}
 #Destroy an existing render texture
 proc destroy*(renderTexture: PRenderTexture){.
@@ -554,9 +555,9 @@ proc copy*(font: PFont): PFont {.
   cdecl, importc: "sfFont_copy", dynlib: LibG.}
 proc destroy*(font: PFont) {.
   cdecl, importc: "sfFont_destroy", dynlib: LibG.}
-proc getGlyph*(font: PFont, codePoint: Uint32, characterSize: cint, bold: bool): TGlyph{.
+proc getGlyph*(font: PFont, codePoint: uint32, characterSize: cint, bold: bool): TGlyph{.
   cdecl, importc: "sfFont_getGlyph", dynlib: LibG.}
-proc getKerning*(font: PFont, first: Uint32, second: Uint32, characterSize: cint): cint {.
+proc getKerning*(font: PFont, first: uint32, second: uint32, characterSize: cint): cint {.
   cdecl, importc: "sfFont_getKerning", dynlib: LibG.}
 proc getLineSpacing*(font: PFont, characterSize: cint): cint {.
   cdecl, importc: "sfFont_getLineSpacing", dynlib: LibG.}
@@ -981,7 +982,7 @@ proc getInverseTransform*(text: PText): TTransform {.
   cdecl, importc: "sfText_getInverseTransform", dynlib: LibG.}
 proc setString*(text: PText, string: cstring) {.
   cdecl, importc: "sfText_setString", dynlib: LibG.}
-proc setUnicodeString*(text: PText, string: ptr Uint32) {.
+proc setUnicodeString*(text: PText, string: ptr uint32) {.
   cdecl, importc: "sfText_setUnicodeString", dynlib: LibG.}
 proc setFont*(text: PText, font: PFont) {.
   cdecl, importc: "sfText_setFont", dynlib: LibG.}
@@ -993,13 +994,13 @@ proc setColor*(text: PText, color: TColor) {.
   cdecl, importc: "sfText_setColor", dynlib: LibG.}
 proc getString*(text: PText): cstring {.
   cdecl, importc: "sfText_getString", dynlib: LibG.}
-proc getUnicodeString*(text: PText): ptr Uint32 {.cdecl, 
+proc getUnicodeString*(text: PText): ptr uint32 {.cdecl, 
   importc: "sfText_getUnicodeString", dynlib: LibG.}
 proc getFont*(text: PText): PFont {.
   cdecl, importc: "sfText_getFont", dynlib: LibG.}
 proc getCharacterSize*(text: PText): cint {.
   cdecl, importc: "sfText_getCharacterSize", dynlib: LibG.}
-proc getStyle*(text: PText): Uint32 {.
+proc getStyle*(text: PText): uint32 {.
   cdecl, importc: "sfText_getStyle", dynlib: LibG.}
 proc getColor*(text: PText): TColor {.
   cdecl, importc: "sfText_getColor", dynlib: LibG.}
@@ -1177,9 +1178,9 @@ proc Microseconds*(us: int64): TTime #{.  cdecl, importc: "sfMicroseconds", dynl
 
 {.pop.}
 
-proc `-`*(a, b: csfml.TTime): csfml.TTime {.inline.} = microseconds(a.asMicroseconds - b.asMicroseconds)
+proc `-`*(a, b: csfml.TTime): csfml.TTime {.inline.} = TTime(microseconds: (a.asMicroseconds - b.asMicroseconds))
 proc `-=`*(a: var csfml.TTime; b: csfml.TTime) {.inline.} = a = a - b
-proc `+`*(a, b: csfml.TTime): csfml.TTime {.inline.} = microseconds(a.asMicroseconds + b.asMicroseconds)
+proc `+`*(a, b: csfml.TTime): csfml.TTime {.inline.} = TTime(microseconds: (a.asMicroseconds + b.asMicroseconds))
 proc `+=`*(a: var csfml.TTime; b: csfml.TTime) {.inline.} = a = a + b
 proc `<`*(a, b: csfml.TTime): bool {.inline.} = a.asMicroseconds < b.asMicroseconds
 let ZeroTime* = microseconds(0)
@@ -1358,6 +1359,9 @@ proc newRenderWindow*(handle: TWindowHandle, settings: PContextSettings = nil): 
 proc newRenderWindow*(mode: TVideoMode, title: cstring, style: int32, settings: PContextSettings = nil): PRenderWindow {.inline.}=
   RenderWindow_create(mode, title, style, settings)
 
+{.push importc: "sf$1".}
+{.push dynlib: LibW.}
+
 proc getMousePosition*(relativeTo: PWindow): TVector2i {.inline.} = 
   mouseGetPosition(relativeTo)
 proc setMousePosition*(pos: TVector2i; relativeTo: PWindow){.inline.}=
@@ -1365,5 +1369,7 @@ proc setMousePosition*(pos: TVector2i; relativeTo: PWindow){.inline.}=
 proc setMousePosition*(window: PWindow; pos: TVector2i) {.inline.} =
   mouseSetPosition(pos, window)
 
+{.pop.}
+{.pop.}
 
 proc newClock*(): PClock {.inline.} = Clock_Create()

--- a/csfml.nim
+++ b/csfml.nim
@@ -1372,4 +1372,4 @@ proc setMousePosition*(window: PWindow; pos: TVector2i) {.inline.} =
 {.pop.}
 {.pop.}
 
-proc newClock*(): PClock {.inline.} = Clock_create()
+proc newClock*(): PClock {.inline.} = Clock_Create()

--- a/csfml_audio.nim
+++ b/csfml_audio.nim
@@ -349,7 +349,7 @@ proc saveToFile*(soundBuffer: PSoundBuffer; filename: cstring): bool {.
 #/ \return Read-only pointer to the array of sound samples
 #/
 #//////////////////////////////////////////////////////////
-proc sfSoundBuffer_getSamples*(soundBuffer: PSoundBuffer): ptr Int16{.
+proc sfSoundBuffer_getSamples*(soundBuffer: PSoundBuffer): ptr int16{.
   cdecl, importc: "sfSoundBuffer_getSamples", dynlib: Lib.}
 #//////////////////////////////////////////////////////////
 #/ \brief Get the number of samples stored in a sound buffer


### PR DESCRIPTION
Mostly just case sensitivity (Uint8 vs uint8) changes so that this works after bigbreak

Also: 
1) I changed the get/set mouse position procs so that they imported from libcsfml-window.
2) The -, -=, and +/+= operators for TTime needed some tweaking.

I'm not really sure how the newClock procedure finds the Clock_Create() procedure, so that might need to be changed back to import sfClock_create from libcsfml-system? I didn't change it since I thought you're probably doing something clever.  :)
